### PR TITLE
GetFeatureCount() method return Int value not Long

### DIFF
--- a/main/plugins/org.talend.sdi.designer.components/components/sOGRInfoInput/sOGRInfoInput_begin.javajet
+++ b/main/plugins/org.talend.sdi.designer.components/components/sOGRInfoInput/sOGRInfoInput_begin.javajet
@@ -54,7 +54,7 @@
     String fidColumn_<%=cid %> = "";
     String geomColumn_<%=cid %> = "";
     String columnsDef_<%=cid %> = "";
-    long nbFeatures_<%=cid %> = 0;
+    int nbFeatures_<%=cid %> = 0;
     int nbErrors_<%=cid %> = 0;
     String errors_<%=cid %> = "";
     java.util.HashMap<String, double[]> corners_<%=cid %>;


### PR DESCRIPTION
When exporting a job (Contruire le job) we get an error message:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.6.1:compile (default-compile) on project scan_vector: Compilation failure: Compilation failure: 
[ERROR] /home/yjacolin/Documents/Applications/Talend/TOS_DI-20200219_1130-V7.3.1/workspace/METADATACRAWLER/poms/jobs/process/scan_vector_0.1/src/main/java/metadatacrawler/scan_vector_0_1/scan_vector.java:[2599] 
[ERROR] 	row8.nb_features = nbFeatures_sOGRInfoInput_1;
[ERROR] 	                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
[ERROR] Type mismatch: cannot convert from long to Integer
```