### PR TITLE
Dockerfile and instructions for use

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,6 +7,10 @@
  * Copy the content of the plugin directory in the plugins directory of TOS
  * Start TOS
 
+## Run using docker ubuntu image and a vnc server
+
+ * Follow the included instructions in the `docker` folder
+
 ## No spatial component in the palette ?
 
 In configuration/config.ini for osgi.bundles=... property add:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,27 @@
+# Custom Dockerfile for building Talend Spatial
+# Based on dorowu/ubuntu-desktop-lxde-vnc
+# Build with docker build -t crawler .
+
+
+FROM dorowu/ubuntu-desktop-lxde-vnc
+
+MAINTAINER Jo Cook "jocook@astuntechnology.com"
+ENV REFRESHED_AT 2022-08-02
+
+# install some utilities
+RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add -
+RUN apt-get update && apt-get install -y openjdk-8-jdk gdal-bin libgdal-java unzip curl gedit
+
+# Download the additional files that we need
+
+RUN wget --no-check-certificate https://sourceforge.net/projects/sdispatialetl/files/sdispatialetl/TOS.spatial.7.4.1/TOS-Spatial-7.4.1.zip/download -O TOS-Spatial-7.4.1.zip && \
+	wget --no-check-certificate https://sourceforge.net/projects/talend-studio/files/Talend%20Open%20Studio/7.4.1M8/TOS_DI-20210406_1041-V7.4.1M8.zip/download -O TOS_DI-20210406_1041-V7.4.1M8.zip && \
+	wget --no-check-certificate https://talend-update.talend.com/nexus/content/repositories/libraries/org/talend/libraries/log4j-1.2.15/6.0.0/log4j-1.2.15-6.0.0.jar -O log4j-1.2.15-6.0.0.jar
+
+RUN unzip TOS_DI-20210406_1041-V7.4.1M8.zip && \
+	unzip TOS-Spatial-7.4.1.zip
+
+RUN cp -r target/TOS-Spatial-7.4.1/plugins/* TOS_DI-20210406_1041-V7.4.1M8/plugins
+
+
+

--- a/docker/README.md
+++ b/docker/README.md
@@ -38,6 +38,24 @@ Once it's running then you can connect to it using vnc using the following addre
 
 	localhost:5900
 
-Access the menu using the icon in the bottom left corner of the desktop and choose System Tools&rarr;File Manager PCManFM, then navigate to `/data/TOS_DI-20181026_1147-v7.1.1/` and execute (double-click) `TOS_DI-linux-gtk-x86_64`. If it asks you to confirm that you want to execute the file, choose the button marked "Execute". 
+Access the menu using the icon in the bottom left corner of the desktop and choose System Tools&rarr;File Manager PCManFM, then navigate to `/root/TOS_DI-20181026_1147-v7.1.1/` and execute (double-click) `TOS_DI-linux-gtk-x86_64`. If it asks you to confirm that you want to execute the file, choose the button marked "Execute". 
 
 When Talend loads, accept any licenses that you're asked to accept and start a new project. If you have added a volume mount as described above, your files will be located at `/data`.
+
+### No spatial component in the palette ? ###
+
+As detailed in the installation instructions at https://github.com/talend-spatial/talend-spatial/blob/7.4/INSTALL.md if you don't have the **geo** component in your palette when you open Talend-Spatial then you will need to edit `/root/TOS_DI-20181026_1147-v7.1.1/configuration/config.ini` and add:
+
+```
+,org.talend.libraries.sdi-7.4.1@4,org.talend.sdi.designer.components-7.4.1@4,
+org.talend.sdi.designer.routines-7.4.1@4,org.talend.sdi.repository.ui.actions.metadata-7.4.1@4,
+org.talend.sdi.repository.ui.actions.metadata.ogr-7.4.1@4,
+org.talend.sdi.workspace.spatial-7.4.1@4 
+
+```
+
+to the **osgi.bundles=...** property.
+
+Note that this will not persist beyond a restart of the docker container. If you wish to permanently fix this then save the edited `/root/TOS_DI-20181026_1147-v7.1.1/configuration/config.ini` file to your local computer, and mount it as a volume for the docker command. For example:
+
+	docker run --name crawler -p 5900:5900 -v /host/path/to/files:/data -v /host/path/to/config.ini:/root/TOS_DI-20181026_1147-v7.1.1/configuration/config.ini crawler

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,43 @@
+# README #
+
+Docker image for running metadata crawler. Based on https://github.com/fcwu/docker-ubuntu-vnc-desktop
+
+## What is this repository for? ##
+
+* Provides a docker image to run an ubuntu server (gui) with Talend Open Source (v7.4) and Talend Spatial installed and configured, that you can connect to from any operating system as long as you have a vnc client.
+
+## How do I get set up? ##
+
+### Build Dependencies ###
+
+* docker
+* a vnc client
+
+### Installation ###
+
+Clone or otherwise download this repository. 
+
+Build docker image inside the `docker` folder using:
+
+	docker build . -t crawler
+
+Start crawler using:
+
+	docker run --name crawler -p 5900:5900 crawler
+
+Optionally add a volume mount for your data (use the correct syntax for the host files- the example below is for a linux host):
+
+	docker run --name crawler -p 5900:5900 -v /host/path/to/files:/data crawler
+
+
+### Connecting and Running ###
+
+Check the status of the container using `docker ps`. If you cannot see a container with name `crawler` in the output then consult the output of the `docker run` command above.
+
+Once it's running then you can connect to it using vnc using the following address:
+
+	localhost:5900
+
+Access the menu using the icon in the bottom left corner of the desktop and choose System Tools&rarr;File Manager PCManFM, then navigate to `/data/TOS_DI-20181026_1147-v7.1.1/` and execute (double-click) `TOS_DI-linux-gtk-x86_64`. If it asks you to confirm that you want to execute the file, choose the button marked "Execute". 
+
+When Talend loads, accept any licenses that you're asked to accept and start a new project. If you have added a volume mount as described above, your files will be located at `/data`.

--- a/docker/README.md
+++ b/docker/README.md
@@ -38,6 +38,6 @@ Once it's running then you can connect to it using vnc using the following addre
 
 	localhost:5900
 
-Access the menu using the icon in the bottom left corner of the desktop and choose System Tools&rarr;File Manager PCManFM, then navigate to `/data/TOS_DI-20181026_1147-v7.1.1/` and execute (double-click) `TOS_DI-linux-gtk-x86_64`. If it asks you to confirm that you want to execute the file, choose the button marked "Execute". 
+Access the menu using the icon in the bottom left corner of the desktop and choose System Tools&rarr;File Manager PCManFM, then navigate to `/root/TOS_DI-20210406_1041-V7.4.1M8/` and execute (double-click) `TOS_DI-linux-gtk-x86_64`. If it asks you to confirm that you want to execute the file, choose the button marked "Execute". 
 
 When Talend loads, accept any licenses that you're asked to accept and start a new project. If you have added a volume mount as described above, your files will be located at `/data`.


### PR DESCRIPTION
- Added clean instructions for building and using a docker image for Talend and Talend Spatial 7.4 release, based on a headless ubuntu server. 
- Added a section to the Install instructions to direct people to the main readme in the docker folder